### PR TITLE
Download Raspberry Pi Base Firmware with Git

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -34,6 +34,11 @@ jobs:
       # Working Directories
       OUT_DIR: /root/out
     steps:
+      - name: Extract Branch
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      
       - name: Login to Docker Container Registry
         uses: actions-hub/docker/login@master
         env:
@@ -61,7 +66,7 @@ jobs:
             -e DEFAULT_DROPBEAR_ENABLED=true \
             -e DEFAULT_HOSTNAME=${{ env.PROFILENAME }} \
             -e INPUT_PATH=${{ github.workspace }} \
-            -e IMG_NAME=${{ env.PROFILENAME }}-${{ env.TAG }}-${{ steps.extract_version.outputs.version }}-${{ env.ARCH }} \
+            -e IMG_NAME=${{ env.PROFILENAME }}-${{ env.TAG }}-${{ steps.extract_branch.outputs.branch }}-${{ env.ARCH }} \
             ${{ secrets.REGISTRY_HOST }}/robin-rpr/raspi-alpine-builder:latest
       
       - name: Copy Artifacts
@@ -73,12 +78,12 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: |
-            ${{ env.PROFILENAME }}-${{ env.TAG }}-${{ steps.extract_version.outputs.version }}-${{ env.ARCH }}
+            ${{ env.PROFILENAME }}-${{ env.TAG }}-${{ steps.extract_branch.outputs.branch }}-${{ env.ARCH }}
           path: |
-            ${{ env.OUT_DIR }}/${{ env.PROFILENAME }}-${{ env.TAG }}-${{ steps.extract_version.outputs.version }}-${{ env.ARCH }}.${{ env.FILE_EXT }}
-            ${{ env.OUT_DIR }}/${{ env.PROFILENAME }}-${{ env.TAG }}-${{ steps.extract_version.outputs.version }}-${{ env.ARCH }}.${{ env.FILE_EXT }}.sha256
-            ${{ env.OUT_DIR }}/${{ env.PROFILENAME }}-${{ env.TAG }}-${{ steps.extract_version.outputs.version }}-${{ env.ARCH }}_update.${{ env.FILE_EXT }}
-            ${{ env.OUT_DIR }}/${{ env.PROFILENAME }}-${{ env.TAG }}-${{ steps.extract_version.outputs.version }}-${{ env.ARCH }}_update.${{ env.FILE_EXT }}.sha256
+            ${{ env.OUT_DIR }}/${{ env.PROFILENAME }}-${{ env.TAG }}-${{ steps.extract_branch.outputs.branch }}-${{ env.ARCH }}.${{ env.FILE_EXT }}
+            ${{ env.OUT_DIR }}/${{ env.PROFILENAME }}-${{ env.TAG }}-${{ steps.extract_branch.outputs.branch }}-${{ env.ARCH }}.${{ env.FILE_EXT }}.sha256
+            ${{ env.OUT_DIR }}/${{ env.PROFILENAME }}-${{ env.TAG }}-${{ steps.extract_branch.outputs.branch }}-${{ env.ARCH }}_update.${{ env.FILE_EXT }}
+            ${{ env.OUT_DIR }}/${{ env.PROFILENAME }}-${{ env.TAG }}-${{ steps.extract_branch.outputs.branch }}-${{ env.ARCH }}_update.${{ env.FILE_EXT }}.sha256
           if-no-files-found: error
 
     

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Login to Docker Container Registry
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
-          name: ${{ secrets.REGISTRY_HOST }}/${{ secrets.REGISTRY_USERNAME }}/raspi-alpine-builder
+          name: ${{ secrets.REGISTRY_USERNAME }}/raspi-alpine-builder/raspi-alpine-builder
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
           registry: ${{ secrets.REGISTRY_HOST }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Login to Docker Container Registry
         uses: elgohr/Publish-Docker-Github-Action@master
-        env:
+        with:
           name: ${{ secrets.REGISTRY_HOST }}/${{ secrets.REGISTRY_USERNAME }}/raspi-alpine-builder
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -19,3 +19,65 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
           registry: ${{ secrets.REGISTRY_HOST }}
+
+  try: # Check image for ARM Cortex-A72
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      # Meta Preferences
+      TAG: try
+      ARCH: armv8
+      VERSION: edge
+      FILE_EXT: img.gz
+      PROFILENAME: bboehmke
+      # Working Directories
+      OUT_DIR: /root/out
+    steps:
+      - name: Login to Docker Container Registry
+        uses: actions-hub/docker/login@master
+        env:
+          DOCKER_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+          DOCKER_REGISTRY_URL: ${{ secrets.REGISTRY_HOST }}
+          
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+      
+      - name: Build Image
+        run: |
+          docker run \
+            --name ${{ env.PROFILENAME }}_${{ env.ARCH }} \
+            -v "${{ github.workspace }}":"${{ github.workspace }}" \
+            -v "${{ env.OUT_DIR }}":"${{ env.OUT_DIR }}" \
+            -v "${{ env.TMP_DIR }}":"${{ env.TMP_DIR }}" \
+            -e ALPINE_BRANCH=${{ env.VERSION }} \
+            -e DEFAULT_ROOT_PASSWORD=${{ env.PROFILENAME }} \
+            -e OUTPUT_PATH=${{ env.OUT_DIR }} \
+            -e DEFAULT_DROPBEAR_ENABLED=true \
+            -e DEFAULT_HOSTNAME=${{ env.PROFILENAME }} \
+            -e INPUT_PATH=${{ github.workspace }} \
+            -e IMG_NAME=${{ env.PROFILENAME }}-${{ env.TAG }}-${{ steps.extract_version.outputs.version }}-${{ env.ARCH }} \
+            ${{ secrets.REGISTRY_HOST }}/robin-rpr/raspi-alpine-builder:latest
+      
+      - name: Copy Artifacts
+        run: |
+          sudo chown -R $(whoami):$(whoami) /root
+          docker cp ${{ env.PROFILENAME }}_${{ env.ARCH }}:${{ env.OUT_DIR }}/. ${{ env.OUT_DIR }}
+      
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: |
+            ${{ env.PROFILENAME }}-${{ env.TAG }}-${{ steps.extract_version.outputs.version }}-${{ env.ARCH }}
+          path: |
+            ${{ env.OUT_DIR }}/${{ env.PROFILENAME }}-${{ env.TAG }}-${{ steps.extract_version.outputs.version }}-${{ env.ARCH }}.${{ env.FILE_EXT }}
+            ${{ env.OUT_DIR }}/${{ env.PROFILENAME }}-${{ env.TAG }}-${{ steps.extract_version.outputs.version }}-${{ env.ARCH }}.${{ env.FILE_EXT }}.sha256
+            ${{ env.OUT_DIR }}/${{ env.PROFILENAME }}-${{ env.TAG }}-${{ steps.extract_version.outputs.version }}-${{ env.ARCH }}_update.${{ env.FILE_EXT }}
+            ${{ env.OUT_DIR }}/${{ env.PROFILENAME }}-${{ env.TAG }}-${{ steps.extract_version.outputs.version }}-${{ env.ARCH }}_update.${{ env.FILE_EXT }}.sha256
+          if-no-files-found: error
+
+    

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,16 +13,9 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Login to Docker Container Registry
-        uses: actions-hub/docker/login@master
+        uses: elgohr/Publish-Docker-Github-Action@master
         env:
-          DOCKER_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
-          DOCKER_REGISTRY_URL: ${{ secrets.REGISTRY_HOST }}
-
-      - name: Build ${{ secrets.REGISTRY_USERNAME }}/raspi-alpine-builder
-        run: docker build -t ${{ secrets.REGISTRY_HOST }}/${{ secrets.REGISTRY_USERNAME }}/raspi-alpine-builder:latest .
-
-      - name: Push node/node to GitHub Container Registry
-        uses: actions-hub/docker@master
-        with:
-          args: push ${{ secrets.REGISTRY_HOST }}/${{ secrets.REGISTRY_USERNAME }}/raspi-alpine-builder:latest
+          name: ${{ secrets.REGISTRY_HOST }}/${{ secrets.REGISTRY_USERNAME }}/raspi-alpine-builder
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+          registry: ${{ secrets.REGISTRY_HOST }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,6 +22,7 @@ jobs:
 
   try: # Check image for ARM Cortex-A72
     runs-on: ubuntu-latest
+    needs: [publish]
     timeout-minutes: 15
     env:
       # Meta Preferences

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,28 @@
+name: Master
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Login to Docker Container Registry
+        uses: actions-hub/docker/login@master
+        env:
+          DOCKER_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+          DOCKER_REGISTRY_URL: ${{ secrets.REGISTRY_HOST }}
+
+      - name: Build ${{ secrets.REGISTRY_USERNAME }}/raspi-alpine-builder
+        run: docker build
+
+      - name: Push node/node to GitHub Container Registry
+        uses: actions-hub/docker@master
+        with:
+          args: push ${{ secrets.REGISTRY_HOST }}/${{ secrets.REGISTRY_USERNAME }}/raspi-alpine-builder:latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Login to Docker Container Registry
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
-          name: ${{ secrets.REGISTRY_USERNAME }}/raspi-alpine-builder/raspi-alpine-builder
+          name: ${{ secrets.REGISTRY_USERNAME }}/raspi-alpine-builder
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
           registry: ${{ secrets.REGISTRY_HOST }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,7 +20,7 @@ jobs:
           DOCKER_REGISTRY_URL: ${{ secrets.REGISTRY_HOST }}
 
       - name: Build ${{ secrets.REGISTRY_USERNAME }}/raspi-alpine-builder
-        run: docker build
+        run: docker build -t ${{ secrets.REGISTRY_HOST }}/${{ secrets.REGISTRY_USERNAME }}/raspi-alpine-builder:latest .
 
       - name: Push node/node to GitHub Container Registry
         uses: actions-hub/docker@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,4 +86,4 @@ COPY --from=uboot_tool /uboot_tool /uboot_tool
 
 WORKDIR /work
 
-CMD ["strace", "-f /bin/sh /resources/build.sh 2>&1"]
+CMD ["/bin/sh", "/resources/build.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,8 @@ RUN arm-linux-gnueabi-gcc -Wall -static -static-libgcc -o /uboot_tool /uboot.c
 
 FROM alpine:3.11
 
+RUN apk add --no-cache strace
+
 RUN apk update && \
     apk add automake build-base git autoconf confuse-dev linux-headers \
             findutils mtools e2fsprogs-extra alpine-sdk dosfstools uboot-tools && \
@@ -84,4 +86,4 @@ COPY --from=uboot_tool /uboot_tool /uboot_tool
 
 WORKDIR /work
 
-CMD ["/bin/sh", "/resources/build.sh"]
+CMD ["strace -f", "/bin/sh", "/resources/build.sh", "2>&1 | less"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,4 +86,4 @@ COPY --from=uboot_tool /uboot_tool /uboot_tool
 
 WORKDIR /work
 
-CMD ["strace -f", "/bin/sh", "/resources/build.sh", "2>&1 | less"]
+CMD ["strace", "-f /bin/sh /resources/build.sh 2>&1"]

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ builder.
 | SIZE_ROOT_FS                | 200M                                 | Size of root file system                                                                          |
 | SIZE_ROOT_PART              | 500M                                 | Size of root partition                                                                            |
 | UBOOT_COUNTER_RESET_ENABLED | true                                 | True to enable simple boot counter reset service                                                  |
-
+| RPI_FIRMWARE_BRANCH         | stable                               | [Raspberry Pi Firmware Branch](https://github.com/raspberrypi/firmware) to use for image                                                    |
 ### Update running system
 
 The system can be updated without a complete flash of the SD card from the 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ builder.
 
 | Variable                    | Default Value                        | Description                                                                                       |
 | --------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| ALPINE_BRANCH               | 3.11                                 | [Alpine Branch](https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases) to use for image         |
+| ALPINE_BRANCH               | v3.11                                | [Alpine Branch](https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases) to use for image         |
 | ALPINE_MIRROR               | http://dl-cdn.alpinelinux.org/alpine | Mirror used for package download                                                                  |
 | CUSTOM_IMAGE_SCRIPT         | image.sh                             | Name of script for image customizations (relative to input dir)                                   |
 | DEFAULT_DROPBEAR_ENABLED    | true                                 | True to enable SSH server by default                                                              |

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ builder.
 
 | Variable                    | Default Value                        | Description                                                                                       |
 | --------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| ALPINE_BRANCH               | v3.11                                | [Alpine Branch](https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases) to use for image         |
+| ALPINE_BRANCH               | v3.11                                | [Alpine Branch](https://alpinelinux.org/releases) to use for image         |
 | ALPINE_MIRROR               | http://dl-cdn.alpinelinux.org/alpine | Mirror used for package download                                                                  |
 | CUSTOM_IMAGE_SCRIPT         | image.sh                             | Name of script for image customizations (relative to input dir)                                   |
 | DEFAULT_DROPBEAR_ENABLED    | true                                 | True to enable SSH server by default                                                              |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ builder.
 | SIZE_ROOT_FS                | 200M                                 | Size of root file system                                                                          |
 | SIZE_ROOT_PART              | 500M                                 | Size of root partition                                                                            |
 | UBOOT_COUNTER_RESET_ENABLED | true                                 | True to enable simple boot counter reset service                                                  |
-| RPI_FIRMWARE_BRANCH         | stable                               | [Raspberry Pi Firmware Branch](https://github.com/raspberrypi/firmware) to use for image                                                    |
+| RPI_FIRMWARE_BRANCH         | stable                               | [Raspberry Pi Firmware Branch](https://github.com/raspberrypi/firmware/branches) to use for image                                                    |
 ### Update running system
 
 The system can be updated without a complete flash of the SD card from the 

--- a/resources/build.sh
+++ b/resources/build.sh
@@ -66,8 +66,8 @@ echo ">> Prepare root FS"
 
 # update local repositories to destination ones to ensure the right packages where installed
 cat >/etc/apk/repositories <<EOF
-${ALPINE_MIRROR}/v${ALPINE_BRANCH}/main
-${ALPINE_MIRROR}/v${ALPINE_BRANCH}/community
+${ALPINE_MIRROR}/${ALPINE_BRANCH}/main
+${ALPINE_MIRROR}/${ALPINE_BRANCH}/community
 EOF
 
 # copy apk keys to new root (required for initial apk add run)

--- a/resources/build.sh
+++ b/resources/build.sh
@@ -24,6 +24,7 @@ set -e
 : ${INPUT_PATH:="/input"}
 : ${CUSTOM_IMAGE_SCRIPT:="image.sh"}
 
+ALPINE_BRANCH=$(echo $ALPINE_BRANCH | sed '/^[^v].*[0-9]/s/^/v/')
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # static config

--- a/resources/build.sh
+++ b/resources/build.sh
@@ -314,6 +314,11 @@ wget -P ${BOOTFS_PATH} https://github.com/raspberrypi/firmware/raw/master/boot/s
 wget -P ${BOOTFS_PATH} https://github.com/raspberrypi/firmware/raw/master/boot/start4db.elf
 wget -P ${BOOTFS_PATH} https://github.com/raspberrypi/firmware/raw/master/boot/start4x.elf
 
+ls -la \
+    ${ROOTFS_PATH} \
+    ${ROOTFS_PATH}/boot \
+    ${ROOTFS_PATH}/boot/dtbs-rpi/
+
 # copy linux device trees and overlays to boot
 cp ${ROOTFS_PATH}/boot/dtbs-rpi/*.dtb ${BOOTFS_PATH}/
 cp -r ${ROOTFS_PATH}/boot/dtbs-rpi/overlays ${BOOTFS_PATH}/

--- a/resources/build.sh
+++ b/resources/build.sh
@@ -4,7 +4,7 @@ set -e
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # User config
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-: ${ALPINE_BRANCH:="3.11"}
+: ${ALPINE_BRANCH:="v3.11"}
 : ${ALPINE_MIRROR:="http://dl-cdn.alpinelinux.org/alpine"}
 
 : ${DEFAULT_TIMEZONE:="Etc/UTC"}

--- a/resources/build.sh
+++ b/resources/build.sh
@@ -314,14 +314,9 @@ wget -P ${BOOTFS_PATH} https://github.com/raspberrypi/firmware/raw/master/boot/s
 wget -P ${BOOTFS_PATH} https://github.com/raspberrypi/firmware/raw/master/boot/start4db.elf
 wget -P ${BOOTFS_PATH} https://github.com/raspberrypi/firmware/raw/master/boot/start4x.elf
 
-ls -la \
-    ${ROOTFS_PATH} \
-    ${ROOTFS_PATH}/boot \
-    ${ROOTFS_PATH}/boot/dtbs-rpi/
-
 # copy linux device trees and overlays to boot
-cp ${ROOTFS_PATH}/boot/dtbs-rpi/*.dtb ${BOOTFS_PATH}/
-cp -r ${ROOTFS_PATH}/boot/dtbs-rpi/overlays ${BOOTFS_PATH}/
+cp ${ROOTFS_PATH}/boot/*.dtb ${BOOTFS_PATH}/
+cp -r ${ROOTFS_PATH}/boot/overlays ${BOOTFS_PATH}/
 
 # copy u-boot
 cp /uboot/* ${BOOTFS_PATH}/


### PR DESCRIPTION
Hey there,

This Pull Request aims to clone the Raspberry Pi Base Firmware with `git` instead of `wget`.
It also adds a new Environment Variable called `RPI_FIRMWARE_BRANCH` that references the HEAD of the Firmware Repository to clone.

I subject `stable` as the default value, due to recent (not confirmed) issues with `master`, mentioned in [Issue #5](https://gitlab.com/bboehmke/raspi-alpine-builder/-/issues/5)

Alternative values for `RPI_FIRMWARE_BRANCH` are `master`, `stable` or `next`. See here:
[https://github.com/raspberrypi/firmware/branches/all](https://github.com/raspberrypi/firmware/branches/all)

Cheers!