### PR TITLE
Minimize rootfs partition size, less flash activity

### DIFF
--- a/resources/build.sh
+++ b/resources/build.sh
@@ -416,10 +416,23 @@ m4 -D xFS=vfat -D xIMAGE=boot.xFS -D xLABEL="BOOT" -D xSIZE="$SIZE_BOOT" \
   "$RES_PATH"/m4/genimage.m4 > "$WORK_PATH"/genimage_boot.cfg
 make_image ${BOOTFS_PATH} ${WORK_PATH}/genimage_boot.cfg
 
-# root partition
-m4 -D xFS=ext4 -D xIMAGE=rootfs.xFS -D xLABEL="rootfs" -D xSIZE="$SIZE_ROOT_FS" \
-  "$RES_PATH"/m4/genimage.m4 > "$WORK_PATH"/genimage_root.cfg
-make_image ${ROOTFS_PATH} ${WORK_PATH}/genimage_root.cfg
+# root partition and shrink to minimum size if desired
+if [ "$SIZE_ROOT_FS" -eq "0" ]
+then
+  colour_echo 'Will shrink rootfs'
+  m4 -D xFS=ext4 -D xIMAGE=rootfs.xFS -D xLABEL="rootfs" -D xSIZE="$SIZE_ROOT_PART" -D xFEATURES="extents,dir_index" -D xEXTRAARGS="-m 0" \
+    "$RES_PATH"/m4/genimage_ext4.m4 > "$WORK_PATH"/genimage_root.cfg
+  make_image ${ROOTFS_PATH} ${WORK_PATH}/genimage_root.cfg
+  resize2fs -M ${IMAGE_PATH}/rootfs.ext4
+  SIZE="$(dumpe2fs -h ${IMAGE_PATH}/rootfs.ext4 | awk -F: '/Block count/{count=$2} /Block size/{size=$2} END{print count*size}')"
+  truncate -s "$SIZE" ${IMAGE_PATH}/rootfs.ext4
+  colour_echo "Shrunk rootfs to $SIZE bytes"
+else
+  colour_echo 'Will not shrink rootfs'
+  m4 -D xFS=ext4 -D xIMAGE=rootfs.xFS -D xLABEL="rootfs" -D xSIZE="$SIZE_ROOT_FS" \
+    "$RES_PATH"/m4/genimage.m4 > "$WORK_PATH"/genimage_root.cfg
+  make_image ${ROOTFS_PATH} ${WORK_PATH}/genimage_root.cfg
+fi
 
 # data partition
 m4 -D xFS=ext4 -D xIMAGE=datafs.xFS -D xLABEL="data" -D xSIZE="$SIZE_DATA" \

--- a/resources/m4/genimage_ext4.m4
+++ b/resources/m4/genimage_ext4.m4
@@ -1,0 +1,8 @@
+image xIMAGE {
+  xFS {
+    label = "xLABEL"
+    features = "xFEATURES"
+    extraargs = "xEXTRAARGS"
+  }
+  size = xSIZE
+}

--- a/tests/simple-image/build_image.sh
+++ b/tests/simple-image/build_image.sh
@@ -2,7 +2,7 @@
 set -e
 
 #increase rootfs size to make room for python
-docker run --rm -v "$PWD":/input -v "$PWD"/output/armv7:/output --env SIZE_ROOT_FS="150M" "$CI_REGISTRY/$CI_PROJECT_PATH/$CI_COMMIT_REF_SLUG"
+docker run --rm -v "$PWD":/input -v "$PWD"/output/armv7:/output --env SIZE_ROOT_FS="0" "$CI_REGISTRY/$CI_PROJECT_PATH/$CI_COMMIT_REF_SLUG"
 
 #build for armhf and aarch64 as well
 docker run --rm -v "$PWD":/input -v "$PWD"/output/armhf:/output --env ARCH=armhf --env SIZE_ROOT_FS="150M" "$CI_REGISTRY/$CI_PROJECT_PATH/$CI_COMMIT_REF_SLUG"


### PR DESCRIPTION
This proposes the following changes:
- Change rootfs to ext2 (for a readonly FS we have no need for all the features of ext3/4 like journaling), this saves some space for journal inodes etc
- Use resize2fs and other utilities to reduce the size of `rootfs.ext2` to the smallest possible, this means flashes go quicker as it only has to re-write the portion of the rootfs partition that actually contains data (allows you to reserve a large space for rootfs for future expansion, but not use it immediately and slow down updates unnecessarily)