### PR TITLE
load kernel at 0x00200000 to avoid firmware bug notification

### DIFF
--- a/resources/build.sh
+++ b/resources/build.sh
@@ -267,19 +267,19 @@ colour_echo ">> Prepare kernel for uboot"
 
 # uImage2 is for armhf and armv7 only
 if [ "$ARCH" != "aarch64" ]; then
-  mkimage -A arm -O linux -T kernel -C none -a 0x00008000 -e 0x00008000 -n "Linux kernel" \
+  mkimage -A arm -O linux -T kernel -C none -a 0x00200000 -e 0x00200000 -n "Linux kernel" \
    -d "$ROOTFS_PATH"/boot/vmlinuz-rpi2 "$ROOTFS_PATH"/boot/uImage2
 fi
 
 # there is no uImage4 in armhf
 A=arm
 case "$ARCH" in
-  armhf)   mkimage -A arm -O linux -T kernel -C none -a 0x00008000 -e 0x00008000 -n "Linux kernel" \
+  armhf)   mkimage -A arm -O linux -T kernel -C none -a 0x00200000 -e 0x00200000 -n "Linux kernel" \
             -d "$ROOTFS_PATH"/boot/vmlinuz-rpi "$ROOTFS_PATH"/boot/uImage
            sed "s/uImage4/uImage2/" -i "$RES_PATH"/boot.cmd ;;
   aarch64) A=arm64 ;;
 esac
-[ "$ARCH" != "armhf" ] && mkimage -A "$A" -O linux -T kernel -C none -a 0x00008000 -e 0x00008000 \
+[ "$ARCH" != "armhf" ] && mkimage -A "$A" -O linux -T kernel -C none -a 0x00200000 -e 0x00200000 \
             -n "Linux kernel" -d "$ROOTFS_PATH"/boot/vmlinuz-rpi4 "$ROOTFS_PATH"/boot/uImage4
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #


### PR DESCRIPTION
Currently, when we boot, the kernel prints the following
```
[0.000000] [Firmware Bug]: Kernel image misaligned at boot, please fix your bootloader!
```

This is due to the kernel change requesting (maybe, in the future, requiring?) to be loaded at offsets multiple of 2MB starting with 5.8
See: https://github.com/raspberrypi/firmware/issues/1415

As this does not change the uboot config, this change should be fully forward and backward compatible
